### PR TITLE
Update unrar to 5.3.3

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -1,6 +1,6 @@
 ### UNRAR ###
 _build_unrar() {
-local VERSION="5.2.7"
+local VERSION="5.3.3"
 local FOLDER="unrar"
 local FILE="unrarsrc-${VERSION}.tar.gz"
 local URL="http://www.rarlab.com/rar/${FILE}"

--- a/src/dest/service.sh
+++ b/src/dest/service.sh
@@ -7,8 +7,8 @@
 
 framework_version="2.1"
 name="unrar"
-version="5.2.7"
-description="Unrar 5.2.7"
+version="5.3.3"
+description="Unrar 5.3.3"
 depends=""
 webui=""
 


### PR DESCRIPTION
I have run the 5.3.3 version for a while now and it has been stable and no hiccups since.
Thought it would be convenient for everybody else to have the latest version.
